### PR TITLE
Qf_364-Burn feedback unique survey codes when using ad hoc journey

### DIFF
--- a/src/Employer/ESFA.DAS.EmployerFeedbackEmail.Data/Repositories/EmployerFeedbackRepository.cs
+++ b/src/Employer/ESFA.DAS.EmployerFeedbackEmail.Data/Repositories/EmployerFeedbackRepository.cs
@@ -228,6 +228,12 @@ namespace ESFA.DAS.ProvideFeedback.Data.Repositories
                 , new { uniqueSurveyCode = uniqueSurveyCode });
         }
 
+        public async Task<Guid> GetUniqueSurveyCodeFromFeedbackId(long feedbackId)
+        {
+            return await _dbConnection.QueryFirstOrDefaultAsync<Guid>("SELECT UniqueSurveyCode FROM EmployerSurveyCodes WHERE FeedbackId = @feedbackId"
+                , new { feedbackId = feedbackId });
+        }
+
         public async Task<Guid> CreateEmployerFeedbackResult(long feedbackId, string providerRating, DateTime dateTimeCompleted, FeedbackSource feedbackSource, IEnumerable<ProviderAttribute> providerAttributes)
         {
             var providerAttributesDt = ProviderAttributesToDataTable(providerAttributes);

--- a/src/Employer/ESFA.DAS.EmployerFeedbackEmail.Data/Repositories/IEmployerFeedbackRepository.cs
+++ b/src/Employer/ESFA.DAS.EmployerFeedbackEmail.Data/Repositories/IEmployerFeedbackRepository.cs
@@ -31,6 +31,7 @@ namespace ESFA.DAS.ProvideFeedback.Data.Repositories
         Task<IEnumerable<FeedbackQuestionAttribute>> GetAllAttributes();
         Task<Guid> CreateEmployerFeedbackResult(long feedbackId, string providerRating, DateTime dateTimeCompleted, FeedbackSource feedbackSource, IEnumerable<ProviderAttribute> providerAttributes);
         Task<long> GetFeedbackIdFromUniqueSurveyCode(Guid uniqueCode);
+        Task<Guid> GetUniqueSurveyCodeFromFeedbackId(long feedbackId);
         Task<IEnumerable<EmployerFeedbackViewModel>> GetEmployerFeedback();
         Task<IEnumerable<EmployerFeedbackAndResult>> GetAllFeedbackAndResultFromEmployer(long accountId);
     }

--- a/src/Employer/ESFA.DAS.EmployerProvideFeedback/Controllers/QuestionsController.cs
+++ b/src/Employer/ESFA.DAS.EmployerProvideFeedback/Controllers/QuestionsController.cs
@@ -26,7 +26,7 @@ namespace ESFA.DAS.EmployerProvideFeedback.Controllers
         }
 
         [HttpGet("question-one", Name = RouteNames.QuestionOne_Get)]
-        public async Task<IActionResult> QuestionOne(string encodedAccountId, Guid uniqueCode, string returnUrl = null)
+        public async Task<IActionResult> QuestionOne(string encodedAccountId, string returnUrl = null)
         {
             // TODO: Replace TempData by adding a flag to the ViewModel.
             TempData[ReturnUrlKey] = returnUrl;
@@ -39,7 +39,7 @@ namespace ESFA.DAS.EmployerProvideFeedback.Controllers
         }
 
         [HttpPost("question-one", Name = RouteNames.QuestionOne_Post)]
-        public async Task<IActionResult> QuestionOne(Guid uniqueCode, SurveyModel surveyModel)
+        public async Task<IActionResult> QuestionOne(SurveyModel surveyModel)
         {
             if (!IsProviderAttributesValid(surveyModel))
             {
@@ -74,7 +74,7 @@ namespace ESFA.DAS.EmployerProvideFeedback.Controllers
         }
 
         [HttpGet("question-two", Name = RouteNames.QuestionTwo_Get)]
-        public async Task<IActionResult> QuestionTwo(Guid uniqueCode, string returnUrl = null)
+        public async Task<IActionResult> QuestionTwo(string returnUrl = null)
         {
             TempData[ReturnUrlKey] = returnUrl;
             var idClaim = HttpContext.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier);
@@ -83,7 +83,7 @@ namespace ESFA.DAS.EmployerProvideFeedback.Controllers
         }
 
         [HttpPost("question-two", Name = RouteNames.QuestionTwo_Post)]
-        public async Task<IActionResult> QuestionTwo(Guid uniqueCode, SurveyModel surveyModel)
+        public async Task<IActionResult> QuestionTwo(SurveyModel surveyModel)
         {
             if (!IsProviderAttributesValid(surveyModel))
             {
@@ -101,7 +101,7 @@ namespace ESFA.DAS.EmployerProvideFeedback.Controllers
         
 
         [HttpGet("question-three", Name = RouteNames.QuestionThree_Get)]
-        public async Task<IActionResult> QuestionThree(Guid uniqueCode, string returnUrl = null)
+        public async Task<IActionResult> QuestionThree(string returnUrl = null)
         {
             TempData[ReturnUrlKey] = returnUrl;
             var idClaim = HttpContext.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier);
@@ -110,7 +110,7 @@ namespace ESFA.DAS.EmployerProvideFeedback.Controllers
         }
 
         [HttpPost("question-three", Name = RouteNames.QuestionThree_Post)]
-        public async Task<IActionResult> QuestionThree(Guid uniqueCode, SurveyModel surveyModel)
+        public async Task<IActionResult> QuestionThree(SurveyModel surveyModel)
         {
             if (!ModelState.IsValid)
             {

--- a/src/Employer/ESFA.DAS.EmployerProvideFeedback/Controllers/ReviewAnswersContoller.cs
+++ b/src/Employer/ESFA.DAS.EmployerProvideFeedback/Controllers/ReviewAnswersContoller.cs
@@ -32,7 +32,7 @@ namespace ESFA.DAS.EmployerProvideFeedback.Controllers
         }
 
         [HttpGet("review-answers", Name = RouteNames.ReviewAnswers_Get)]
-        public async Task<IActionResult> Index(Guid uniqueCode)
+        public async Task<IActionResult> Index()
         {
             var idClaim = HttpContext.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier);
             var vm = await _sessionService.Get<SurveyModel>(idClaim.Value);
@@ -41,14 +41,14 @@ namespace ESFA.DAS.EmployerProvideFeedback.Controllers
         }
 
         [HttpPost("review-answers", Name = RouteNames.ReviewAnswers_Post)]
-        public async Task<IActionResult> Confirmation(Guid uniqueCode)
+        public async Task<IActionResult> Confirmation()
         {
             var idClaim = HttpContext.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier);
 
             var answers = await _sessionService.Get<SurveyModel>(idClaim.Value);
 
             answers.Submitted = true;
-            await _orchestrator.SubmitConfirmedEmployerFeedback(answers/*, uniqueCode*/);
+            await _orchestrator.SubmitConfirmedEmployerFeedback(answers);
             await _sessionService.Set(idClaim.Value, answers);
 
             return RedirectToRoute(RouteNames.Confirmation_Get);

--- a/src/Employer/ESFA.DAS.EmployerProvideFeedback/Orchestrators/ReviewAnswersOrchestrator.cs
+++ b/src/Employer/ESFA.DAS.EmployerProvideFeedback/Orchestrators/ReviewAnswersOrchestrator.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using ESFA.DAS.ProvideFeedback.Domain.Entities.Models;
 using ESFA.DAS.ProvideFeedback.Data.Repositories;
+using AspNetCore;
 
 namespace ESFA.DAS.EmployerProvideFeedback.Orchestrators
 {
@@ -59,8 +60,15 @@ namespace ESFA.DAS.EmployerProvideFeedback.Orchestrators
 
                 if(null != surveyModel.UniqueCode && surveyModel.UniqueCode.HasValue)
                 {
-                    // Email journey. Burn the survey code.
+                    // Email journey.
                     await _employerFeedbackRepository.SetCodeBurntDate(surveyModel.UniqueCode.Value);
+                }
+                else
+                {
+                    // Ad Hoc journey
+                    Guid? uniqueSurveyCode = await _employerFeedbackRepository.GetUniqueSurveyCodeFromFeedbackId(feedbackId);
+
+                    await _employerFeedbackRepository.SetCodeBurntDate(uniqueSurveyCode.Value);
                 }
             }
             catch (Exception ex)

--- a/src/Employer/ESFA.DAS.EmployerProvideFeedback/Orchestrators/ReviewAnswersOrchestrator.cs
+++ b/src/Employer/ESFA.DAS.EmployerProvideFeedback/Orchestrators/ReviewAnswersOrchestrator.cs
@@ -67,8 +67,8 @@ namespace ESFA.DAS.EmployerProvideFeedback.Orchestrators
                 {
                     // Ad Hoc journey
                     Guid? uniqueSurveyCode = await _employerFeedbackRepository.GetUniqueSurveyCodeFromFeedbackId(feedbackId);
-
-                    await _employerFeedbackRepository.SetCodeBurntDate(uniqueSurveyCode.Value);
+                    if (uniqueSurveyCode != Guid.Empty)
+                        await _employerFeedbackRepository.SetCodeBurntDate(uniqueSurveyCode.Value);
                 }
             }
             catch (Exception ex)

--- a/src/Employer/UnitTests/EmployerProvideFeedback/Controllers/QuestionsControllerTests.cs
+++ b/src/Employer/UnitTests/EmployerProvideFeedback/Controllers/QuestionsControllerTests.cs
@@ -22,7 +22,6 @@ namespace UnitTests.EmployerProvideFeedback.Controllers
         private Mock<ISessionService> _sessionServiceMock;
         private IFixture _fixture;
         private List<ProviderAttributeModel> _providerAttributes;
-        private Guid _uniqueCode = Guid.NewGuid();
         private string _accountId = string.Empty;
 
         public QuestionsControllerTests()
@@ -62,7 +61,7 @@ namespace UnitTests.EmployerProvideFeedback.Controllers
             // Arrange
 
             // Act
-            var result = await _controller.QuestionOne(_accountId, _uniqueCode) as ViewResult;
+            var result = await _controller.QuestionOne(_accountId) as ViewResult;
 
             // Assert
             Assert.IsAssignableFrom<SurveyModel>(result.Model);
@@ -81,7 +80,7 @@ namespace UnitTests.EmployerProvideFeedback.Controllers
             _sessionServiceMock.Setup(mock => mock.Get<SurveyModel>(It.IsAny<string>())).Returns(Task.FromResult(surveyModel));
 
             // Act
-            var result = await _controller.QuestionOne(_accountId, _uniqueCode) as ViewResult;
+            var result = await _controller.QuestionOne(_accountId) as ViewResult;
 
             // Assert
             Assert.IsAssignableFrom<SurveyModel>(result.Model);
@@ -99,7 +98,7 @@ namespace UnitTests.EmployerProvideFeedback.Controllers
             var surveyModel = new SurveyModel { Attributes = _providerAttributes };
 
             // Act
-            var result = await _controller.QuestionOne(_uniqueCode, surveyModel);
+            var result = await _controller.QuestionOne(surveyModel);
 
             // Assert
             _sessionServiceMock.Verify(mock => mock.Set(It.IsAny<string>(), It.IsAny<object>()), Times.Once);
@@ -114,7 +113,7 @@ namespace UnitTests.EmployerProvideFeedback.Controllers
             _controller.TempData.Add("ReturnUrl", RouteNames.ReviewAnswers_Get);
 
             // Act
-            var result = await _controller.QuestionOne(_uniqueCode, new SurveyModel { Attributes = _providerAttributes });
+            var result = await _controller.QuestionOne(new SurveyModel { Attributes = _providerAttributes });
 
             // Assert
             Assert.IsAssignableFrom<RedirectToRouteResult>(result);
@@ -127,7 +126,7 @@ namespace UnitTests.EmployerProvideFeedback.Controllers
             // Arrange
 
             // Act
-            var result = await _controller.QuestionTwo(_uniqueCode) as ViewResult;
+            var result = await _controller.QuestionTwo() as ViewResult;
 
             // Assert
             Assert.IsAssignableFrom<SurveyModel>(result.Model);
@@ -146,7 +145,7 @@ namespace UnitTests.EmployerProvideFeedback.Controllers
             _sessionServiceMock.Setup(mock => mock.Get<SurveyModel>(It.IsAny<string>())).Returns(Task.FromResult(surveyModel));
 
             // Act
-            var result = await _controller.QuestionTwo(_uniqueCode) as ViewResult;
+            var result = await _controller.QuestionTwo() as ViewResult;
 
             // Assert
             Assert.IsAssignableFrom<SurveyModel>(result.Model);
@@ -164,7 +163,7 @@ namespace UnitTests.EmployerProvideFeedback.Controllers
             var surveyModel = new SurveyModel { Attributes = _providerAttributes };
 
             // Act
-            var result = await _controller.QuestionTwo(_uniqueCode, surveyModel);
+            var result = await _controller.QuestionTwo(surveyModel);
 
             // Assert
             _sessionServiceMock.Verify(mock => mock.Set(It.IsAny<string>(), It.IsAny<object>()), Times.Once);
@@ -179,7 +178,7 @@ namespace UnitTests.EmployerProvideFeedback.Controllers
             _controller.TempData.Add("ReturnUrl", RouteNames.ReviewAnswers_Get);
 
             // Act
-            var result = await _controller.QuestionTwo(_uniqueCode, new SurveyModel { Attributes = _providerAttributes });
+            var result = await _controller.QuestionTwo(new SurveyModel { Attributes = _providerAttributes });
 
             // Assert
             Assert.IsAssignableFrom<RedirectToRouteResult>(result);
@@ -192,7 +191,7 @@ namespace UnitTests.EmployerProvideFeedback.Controllers
             // Arrange
 
             // Act
-            var result = await _controller.QuestionThree(_uniqueCode) as ViewResult;
+            var result = await _controller.QuestionThree() as ViewResult;
 
             // Assert
             Assert.IsAssignableFrom<SurveyModel>(result.Model);
@@ -210,7 +209,7 @@ namespace UnitTests.EmployerProvideFeedback.Controllers
             _sessionServiceMock.Setup(mock => mock.Get<SurveyModel>(It.IsAny<string>())).Returns(Task.FromResult(surveyModel));
 
             // Act
-            var result = await _controller.QuestionThree(_uniqueCode) as ViewResult;
+            var result = await _controller.QuestionThree() as ViewResult;
 
             // Assert
             Assert.IsAssignableFrom<SurveyModel>(result.Model);
@@ -229,7 +228,7 @@ namespace UnitTests.EmployerProvideFeedback.Controllers
             _controller.ModelState.AddModelError("ProviderRating", "Required Field");
 
             // Act
-            var result = await _controller.QuestionThree(_uniqueCode, surveyModel);
+            var result = await _controller.QuestionThree(surveyModel);
 
             // Assert
             _sessionServiceMock.Verify(mock => mock.Set(It.IsAny<string>(), It.IsAny<object>()), Times.Never);
@@ -243,7 +242,7 @@ namespace UnitTests.EmployerProvideFeedback.Controllers
             var surveyModel = new SurveyModel { Rating = ProviderRating.Excellent };
 
             // Act
-            var result = await _controller.QuestionThree(_uniqueCode, surveyModel);
+            var result = await _controller.QuestionThree(surveyModel);
 
             // Assert
             _sessionServiceMock.Verify(mock => mock.Set(It.IsAny<string>(), It.IsAny<object>()), Times.Once);
@@ -259,7 +258,7 @@ namespace UnitTests.EmployerProvideFeedback.Controllers
             _controller.TempData.Add("ReturnUrl", RouteNames.ReviewAnswers_Get);
 
             // Act
-            var result = await _controller.QuestionThree(_uniqueCode, surveyModel);
+            var result = await _controller.QuestionThree(surveyModel);
 
             // Assert
             Assert.IsAssignableFrom<RedirectToRouteResult>(result);

--- a/src/Employer/UnitTests/Orchestrators/ReviewAnswersOrchestratorTests.cs
+++ b/src/Employer/UnitTests/Orchestrators/ReviewAnswersOrchestratorTests.cs
@@ -1,0 +1,66 @@
+﻿using AutoFixture.Xunit2;
+using ESFA.DAS.EmployerProvideFeedback.Orchestrators;
+using ESFA.DAS.EmployerProvideFeedback.ViewModels;
+using ESFA.DAS.ProvideFeedback.Data.Repositories;
+using ESFA.DAS.ProvideFeedback.Domain.Entities.Models;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace UnitTests.Orchestrators
+{
+    public class ReviewAnswersOrchestratorTests
+    {
+        private readonly ReviewAnswersOrchestrator orchestrator;
+        private readonly Mock<IEmployerFeedbackRepository> employerFeedbackRepository;
+        private readonly Mock<ILogger<ReviewAnswersOrchestrator>> logger;
+
+        private readonly Mock<EmployerFeedback> employerFeedback;
+
+        public ReviewAnswersOrchestratorTests()
+        {
+            employerFeedbackRepository = new Mock<IEmployerFeedbackRepository>();
+            logger = new Mock<ILogger<ReviewAnswersOrchestrator>>();
+            orchestrator = new ReviewAnswersOrchestrator(employerFeedbackRepository.Object, logger.Object);
+
+            employerFeedback = new Mock<EmployerFeedback>();
+        }
+
+        [Theory, AutoData]
+        public async void WhenUsingEmailJourney_ThenBurnDateIsSet(SurveyModel surveyModel)
+        {
+            //Arrange
+            employerFeedback.Object.FeedbackId = 1;
+            employerFeedbackRepository.Setup(x => x.GetEmployerFeedbackRecord(surveyModel.UserRef, surveyModel.AccountId, surveyModel.Ukprn))
+                .ReturnsAsync(employerFeedback.Object);
+           
+            //Act
+            await orchestrator.SubmitConfirmedEmployerFeedback(surveyModel);
+
+            //Assert
+            employerFeedbackRepository.Verify(x => x.SetCodeBurntDate(It.IsAny<Guid>()), Times.Once);
+            employerFeedbackRepository.Verify(x => x.GetUniqueSurveyCodeFromFeedbackId(It.IsAny<long>()), Times.Never);
+        }
+
+        [Theory, AutoData]
+        public async void WhenUsingAdHocJourney_ThenBurnDateIsSet(SurveyModel surveyModel)
+        {
+            //Arrange
+            surveyModel.UniqueCode = null;
+
+            employerFeedback.Object.FeedbackId = 1;
+            employerFeedbackRepository.Setup(x => x.GetEmployerFeedbackRecord(surveyModel.UserRef, surveyModel.AccountId, surveyModel.Ukprn))
+                .ReturnsAsync(employerFeedback.Object);
+
+            //Act
+            await orchestrator.SubmitConfirmedEmployerFeedback(surveyModel);
+
+            //Assert
+            employerFeedbackRepository.Verify(x => x.SetCodeBurntDate(It.IsAny<Guid>()), Times.Once);
+            employerFeedbackRepository.Verify(x => x.GetUniqueSurveyCodeFromFeedbackId(It.IsAny<long>()), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
Also removed unique survey code variable from controller methods as they are now passed through as part of the survey model object.