### PR TITLE
QF-1050 - Change auth check on home controller

### DIFF
--- a/src/Employer/ESFA.DAS.EmployerProvideFeedback/Authentication/PolicyNames.cs
+++ b/src/Employer/ESFA.DAS.EmployerProvideFeedback/Authentication/PolicyNames.cs
@@ -2,6 +2,7 @@ namespace ESFA.DAS.EmployerProvideFeedback.Authentication
 {
     public static class PolicyNames
     {
+        public static string EmployerAuthenticated => nameof(EmployerAuthenticated);
         public static string HasEmployerAccount => nameof(HasEmployerAccount);
         public static string HasEmployerViewerTransactorAccount => nameof(HasEmployerViewerTransactorAccount);
     }

--- a/src/Employer/ESFA.DAS.EmployerProvideFeedback/Controllers/HomeController.cs
+++ b/src/Employer/ESFA.DAS.EmployerProvideFeedback/Controllers/HomeController.cs
@@ -39,7 +39,7 @@ namespace ESFA.DAS.EmployerProvideFeedback.Controllers
             _logger = logger;
         }
 
-        [Authorize(Policy = nameof(PolicyNames.EmployerAuthenticated))]
+        [Authorize(Policy = nameof(PolicyNames.HasEmployerAccount))]
         [HttpGet]
         [Route(RoutePrefixPaths.FeedbackRoutePath, Name = RouteNames.Landing_Get_New)]
         public async Task<IActionResult> Index(StartFeedbackRequest request)

--- a/src/Employer/ESFA.DAS.EmployerProvideFeedback/Controllers/HomeController.cs
+++ b/src/Employer/ESFA.DAS.EmployerProvideFeedback/Controllers/HomeController.cs
@@ -39,7 +39,7 @@ namespace ESFA.DAS.EmployerProvideFeedback.Controllers
             _logger = logger;
         }
 
-        [Authorize(Policy = nameof(PolicyNames.HasEmployerAccount))]
+        [Authorize(Policy = nameof(PolicyNames.EmployerAuthenticated))]
         [HttpGet]
         [Route(RoutePrefixPaths.FeedbackRoutePath, Name = RouteNames.Landing_Get_New)]
         public async Task<IActionResult> Index(StartFeedbackRequest request)
@@ -58,7 +58,7 @@ namespace ESFA.DAS.EmployerProvideFeedback.Controllers
             return View();
         }
         
-        [Authorize(Policy = nameof(PolicyNames.HasEmployerAccount))]
+        [Authorize(Policy = nameof(PolicyNames.EmployerAuthenticated))]
         [ServiceFilter(typeof(EnsureFeedbackNotSubmitted))]
         [Route(RoutePrefixPaths.FeedbackFromEmailRoutePath, Name = RouteNames.Landing_Get)]
         [HttpGet]

--- a/src/Employer/ESFA.DAS.EmployerProvideFeedback/StartupExtensions/AuthenticationExtensions.cs
+++ b/src/Employer/ESFA.DAS.EmployerProvideFeedback/StartupExtensions/AuthenticationExtensions.cs
@@ -29,6 +29,12 @@ namespace ESFA.DAS.EmployerProvideFeedback.StartupExtensions
             
             services.AddAuthorization(options =>
             {
+                options.AddPolicy(PolicyNames.EmployerAuthenticated
+                , policy =>
+                {
+                    policy.RequireClaim(EmployerClaims.EmailAddress);
+                    policy.RequireAuthenticatedUser();
+                });
                 options.AddPolicy(
                     PolicyNames.HasEmployerAccount
                     , policy =>


### PR DESCRIPTION
Check on the home controller for getting and submitting feedback will now only check the user is authenticated and not do the check on account id access